### PR TITLE
replace pycrypto with python-cryptography

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>roslib</exec_depend>
 
   <depend>bitbots_docs</depend>
+  <depend>python-cryptography</depend>
 
   <export></export>
 </package>


### PR DESCRIPTION
## Proposed changes
As described in #7 pycrypto has been deprecated and should be replaced. This PR closes #7 by replacing it with [python-cryptography](https://pypi.org/project/cryptography/)

## Related issues
closes #7

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

