### PR TITLE
Add CI configuration and `.rdmanifest` file

### DIFF
--- a/.rdmanifest
+++ b/.rdmanifest
@@ -1,0 +1,15 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/udp_bridge'
+depends:
+- bitbots_docs
+- python3-cryptography
+- roslib
+- rospy
+exec-path: udp_bridge-master
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/udp_bridge'
+uri: https://github.com/bit-bots/udp_bridge/archive/refs/heads/master.tar.gz

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,7 @@
+@Library('bitbots_jenkins_library') import de.bitbots.jenkins.*;
+
+defineProperties()
+
+def pipeline = new BitbotsPipeline(this, env, currentBuild, scm)
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("udp_bridge", ".")))
+pipeline.execute()

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
   <exec_depend>roslib</exec_depend>
 
   <depend>bitbots_docs</depend>
-  <depend>python-cryptography</depend>
+  <depend>python3-cryptography</depend>
 
   <export></export>
 </package>


### PR DESCRIPTION
## Proposed changes
This PR adds a Jenkinsfile to configure our CI to automatically build this package.
It also contains an .rdmanifest which is necessary for this package to be installable as a dependency through rosdep in CI.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

