### PR TITLE
increase test timeouts to make them pass

### DIFF
--- a/test/rostests/test_sender.py
+++ b/test/rostests/test_sender.py
@@ -19,7 +19,7 @@ class SenderTestCase(RosNodeTestCase):
         publisher.publish(msg.String("Hello World"))
 
         # assert that a message is sent by trying to receive it
-        self.assertIsNotNone(sock.recv(10240))
+        self.with_assertion_grace_period(lambda: self.assertIsNotNone(sock.recv(10240)), 1000 * 5)
 
 
 if __name__ == "__main__":

--- a/test/rostests/test_sender_receiver.py
+++ b/test/rostests/test_sender_receiver.py
@@ -18,7 +18,7 @@ class SenderReceiverTestCase(RosNodeTestCase):
         publisher.publish(msg.String("Hello World"))
 
         # verification
-        self.with_assertion_grace_period(subscriber.assertOneMessageReceived, 1000)
+        self.with_assertion_grace_period(subscriber.assertOneMessageReceived, 1000 * 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
previously udp_bridges tests were very volatile. some timeouts have been
increased to address that issue.

