### PR TITLE
Fix diagnostics topic

### DIFF
--- a/config/udp_bridge.yaml
+++ b/config/udp_bridge.yaml
@@ -26,7 +26,7 @@
       - /animation/result
       - /animation/feedback
       - /animation
-      - /diagnostics
+      - /diagnostics_agg
       - /joint_states
       - /imu/data
       - /buttons


### PR DESCRIPTION
## Proposed changes
Upd_bridge now subscribes to `/diagnostics_agg` instead of `/diagnostics`