### PR TITLE
Fix remote code execution due to pickle

### DIFF
--- a/udp_bridge/message_handler.py
+++ b/udp_bridge/message_handler.py
@@ -1,7 +1,13 @@
+import io
 import pickle
 import zlib
 
 from udp_bridge.aes_helper import AESCipher
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        raise pickle.UnpicklingError("pickle loading restricted to base types")
 
 
 class MessageHandler:
@@ -15,4 +21,4 @@ class MessageHandler:
     def decrypt_and_decode(self, msg: bytes):
         decrypted_msg = self.cipher.decrypt(msg)
         binary_msg = zlib.decompress(decrypted_msg)
-        return pickle.loads(binary_msg)
+        return RestrictedUnpickler(io.BytesIO(binary_msg)).load()

--- a/udp_bridge/receiver.py
+++ b/udp_bridge/receiver.py
@@ -6,6 +6,8 @@ from threading import Thread
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
+from rclpy.serialization import deserialize_message
+from rosidl_runtime_py.utilities import get_message
 
 from udp_bridge.message_handler import MessageHandler
 
@@ -47,7 +49,8 @@ class UdpBridgeReceiver:
         """
         try:
             deserialized_msg = self.message_handler.decrypt_and_decode(msg)
-            data = deserialized_msg.get("data")
+            msg_type_name = deserialized_msg.get("msg_type_name")
+            data = deserialize_message(deserialized_msg.get("data"), get_message(msg_type_name))
             topic: str = deserialized_msg.get("topic")
             hostname: str = deserialized_msg.get("hostname")
             latched: bool = deserialized_msg.get("latched")


### PR DESCRIPTION
# Summary
Closes #34.

The problem with using ROS serialization only is that we also have to send the message metadata (topic, hostname, latched, message type). To send them, we need another type of container. A module like `struct` is not really suitable because it does not support variable-length data like strings.
So now, the serialization is used on the message. Then, this is added to a dict with the other metadata. This is then pickled, compressed, and encrypted. Because the pickle now only uses native types (`str`, `bool`, `bytes`), we can forbid any other kind of data. Due to the serialization of the message, we now also have to send the message type, it is no longer coded into the pickle object.