### PR TITLE
add raise RobotNotConfiguredError

### DIFF
--- a/udp_bridge/sender.py
+++ b/udp_bridge/sender.py
@@ -4,7 +4,7 @@ import socket
 from queue import Empty, Full, Queue
 
 import rclpy
-from bitbots_utils.utils import get_parameters_from_other_node, RobotNotConfiguredError
+from bitbots_utils.utils import RobotNotConfiguredError, get_parameters_from_other_node
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.logging import LoggingSeverity
 from rclpy.node import Node

--- a/udp_bridge/sender.py
+++ b/udp_bridge/sender.py
@@ -155,8 +155,10 @@ class UdpBridgeSender:
         self.freq: float = node.get_parameter("send_frequency").value
 
         target_ip_parameter_name: str = "monitoring_host_ip"
-        self.params_blackboard = get_parameters_from_other_node(node, "parameter_blackboard", [target_ip_parameter_name])
-        if any( param_val is None for param_val in self.params_blackboard.values()):
+        self.params_blackboard = get_parameters_from_other_node(
+            node, "parameter_blackboard", [target_ip_parameter_name]
+            )
+        if any(param_val is None for param_val in self.params_blackboard.values()):
             error_text = """
 The robot is not configured properly or the parameter_blackboard is not found.
 It is likely that the robot was not configured when you syncronised your clean code onto the robot.

--- a/udp_bridge/sender.py
+++ b/udp_bridge/sender.py
@@ -157,7 +157,7 @@ class UdpBridgeSender:
         target_ip_parameter_name: str = "monitoring_host_ip"
         self.params_blackboard = get_parameters_from_other_node(
             node, "parameter_blackboard", [target_ip_parameter_name]
-            )
+        )
         if any(param_val is None for param_val in self.params_blackboard.values()):
             error_text = """
 The robot is not configured properly or the parameter_blackboard is not found.
@@ -202,9 +202,6 @@ Run the deploy_robots script with the -c option to configure the robot and set p
 
             except Empty:
                 pass
-
-
-         
 
 
 def main():

--- a/udp_bridge/sender.py
+++ b/udp_bridge/sender.py
@@ -4,7 +4,7 @@ import socket
 from queue import Empty, Full, Queue
 
 import rclpy
-from bitbots_utils.utils import get_parameters_from_other_node
+from bitbots_utils.utils import get_parameters_from_other_node, RobotNotConfiguredError
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.logging import LoggingSeverity
 from rclpy.node import Node
@@ -155,8 +155,15 @@ class UdpBridgeSender:
         self.freq: float = node.get_parameter("send_frequency").value
 
         target_ip_parameter_name: str = "monitoring_host_ip"
-        params_blackboard = get_parameters_from_other_node(node, "parameter_blackboard", [target_ip_parameter_name])
-        self.target: str = params_blackboard[target_ip_parameter_name]
+        self.params_blackboard = get_parameters_from_other_node(node, "parameter_blackboard", [target_ip_parameter_name])
+        if any( param_val is None for param_val in self.params_blackboard.values()):
+            error_text = """
+The robot is not configured properly or the parameter_blackboard is not found.
+It is likely that the robot was not configured when you syncronised your clean code onto the robot.
+Run the deploy_robots script with the -c option to configure the robot and set parameters like the robot id and its role."""
+            self._node.get_logger().fatal(error_text)
+            raise RobotNotConfiguredError(error_text)
+        self.target: str = self.params_blackboard[target_ip_parameter_name]
         self.port: int = node.get_parameter("port").value
         self.sock = self.setup_udp_socket()
 
@@ -193,6 +200,9 @@ class UdpBridgeSender:
 
             except Empty:
                 pass
+
+
+         
 
 
 def main():


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Now a error will be raised when parameters from the parameter_blackboard are None. This also minimizes the errors in the case that the robot config is not set and it is easier to detect that the robot needs to be configured.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [x] Test on the robot
- [ ] This PR is on our `Software` project board
